### PR TITLE
(setup.sh, zsh): fd and __open_in_editor changes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,6 +45,7 @@ install_programs() {
     fzf
     ranger
     ripgrep
+    fd-find
   )
 
   info_message "Installing programs"

--- a/zsh/key-bindings.zsh
+++ b/zsh/key-bindings.zsh
@@ -1,16 +1,20 @@
 __open_in_editor(){
-  local option=$(command find . -not -path '*/node_modules*' -not -path '*.git*' | command fzf --reverse)
+  if [ -z "$EDITOR" ]; then
+   zle -M "Error: cannot open file, no default editor set!" && return 1
+  fi
+
+  local option=$(command fdfind --exclude node_modules | command fzf --reverse)
   if [ -n "$option" ]; then
-    local option_path=$(command realpath $option || command readlink -f $option)
+    local option_path="$(pwd)/$option"
     case "$EDITOR" in
-      "nvim")
+      nvim)
         if [ -f "$option_path" ]; then
           $EDITOR -c "cd $(command dirname $option_path)" $option_path
         else
           $EDITOR -c "cd $option_path" $option_path
         fi
         ;;
-      "vim")
+      vim)
         if [ -f "$option_path" ]; then
           echo $option_path | xargs -o $EDITOR -c "cd $(command dirname $option_path)"
         else

--- a/zsh/zprofile.slink
+++ b/zsh/zprofile.slink
@@ -1,1 +1,2 @@
 export MOZ_ENABLE_WAYLAND=1
+export FZF_DEFAULT_COMMAND="fdfind . --hidden --exclude {.git, node_modules}"


### PR DESCRIPTION
-Added fd-find to the list of programs that are installed during the setup process
-fzf was changed to use fd-find by default
-__open_in_editor was changed to use fd-find instead of find
-__open_in_editor was changed to handle missing EDITOR env
-getting the path to the selected file/dir in __open_in_editor was simplified