### PR TITLE
Removing OhMyZsh from the config

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -10,7 +10,5 @@ alias gs="git status"
 alias gr="git restore"
 alias grs="git restore --staged"
 alias gsw="git switch"
-alias gbsup='git branch --set-upstream-to=origin/$(git_current_branch)'
-alias gpsup='git push --set-upstream origin $(git_current_branch)'
 alias gd='git diff'
 

--- a/misc/git_status.lua
+++ b/misc/git_status.lua
@@ -7,20 +7,20 @@ local git_status = {
   ahead = 0,
   conflicts = 0,
   staged = 0,
-  changed = 0,
+  modified = 0,
   deleted = 0,
   untracked = 0,
   stashed = 0,
 }
 
-function promptPrint()
-  local prompOutput = {
+function prompt_print()
+  local promp_output = {
     branch = "%{$fg_bold[magenta]%}",
     behind = "%{↓%G%}",
     ahead = "%{↑%G%}",
     conflicts = "%{$fg[red]%}%{✖%G%}",
     staged = "%{$fg[red]%}%{●%G%}",
-    changed = "%{$fg_bold[green]%}%{+%G%}",
+    modified = "%{$fg_bold[green]%}%{+%G%}",
     deleted = "%{$fg_bold[blue]%}%{-%G%}",
     untracked = "%{$fg[cyan]%}%{?%G%}",
     stashed = "%{$fg_bold[blue]%}%{⚑%G%}",
@@ -29,72 +29,76 @@ function promptPrint()
 
   for key, value in pairs(git_status) do
     if value and value ~= 0 then
-      prompOutput[key] = prompOutput[key] .. value .. prompOutput.reset
+      promp_output[key] = promp_output[key] .. value .. promp_output.reset
     else
-      prompOutput[key] = ''
+      promp_output[key] = ''
     end
   end
 
   print(
-    prompOutput.branch ..
-    prompOutput.behind ..
-    prompOutput.ahead ..
-    prompOutput.conflicts ..
-    prompOutput.staged ..
-    prompOutput.changed ..
-    prompOutput.deleted ..
-    prompOutput.untracked ..
-    prompOutput.stashed
+    promp_output.branch ..
+    promp_output.behind ..
+    promp_output.ahead ..
+    promp_output.conflicts ..
+    promp_output.staged ..
+    promp_output.modified ..
+    promp_output.deleted ..
+    promp_output.untracked ..
+    promp_output.stashed
   )
 end
 
-function longPrint()
+function long_print()
   for k, v in pairs(git_status) do
     print(k .. " " .. v)
   end
 end
 
-function shortPrint()
+function short_print()
   print(
     git_status.branch .. " " ..
     git_status.behind .. " " ..
     git_status.ahead .. " " ..
     git_status.conflicts .. " " ..
     git_status.staged .. " " ..
-    git_status.changed .. " " ..
+    git_status.modified .. " " ..
     git_status.deleted .. " " ..
     git_status.untracked .. " " ..
     git_status.stashed
   )
 end
 
-function setStashCount()
+function set_stash_count()
   stash_handle = io.popen('git stash list | grep "$(git rev-parse --abbrev-ref HEAD)" | wc -l')
   git_status.stashed = stash_handle:read("n")
   stash_handle:close()
 end
 
-function getTagOrRef()
-  local tag_handle = io.popen("git describe --tags")
+function get_tag_or_ref()
+  local tag_handle = io.popen("git describe --tags 2> /dev/null")
   local tag = tag_handle:read("*a")
-  tag_handle:close()
+  local tag_ok = tag_handle:close()
 
-  if tag then
-    return tag
-  else
-    local ref_handle = io.popen("git rev-parse --short HEAD")
-    local ref = ref_handle:read("*a")
-    ref_handle:close()
-
-    return ref
+  if tag_ok and tag then
+    return trim(tag)
   end
+
+  local ref_handle = io.popen("git rev-parse --short HEAD")
+  local ref = ref_handle:read("*a")
+  ref_handle:close()
+
+  return trim(ref) .. "..."
 end
 
-function setBranchName(line)
+function trim(s)
+  return s:match "^%s*(.*)":match "(.-)%s*$"
+end
+
+function set_branch_name(line)
   if line:find("Initial commit on") or line:find("No commits yet on") then
     git_status.branch = line:match("(%S+)%s*$")
   elseif line:find("no branch") then
-    git_status.branch = getTagOrRef()
+    git_status.branch = get_tag_or_ref()
   else
     local name_start = 4
     local name_end = line:find("%.%.%.")
@@ -107,7 +111,7 @@ function setBranchName(line)
   end
 end
 
-function setTrackingInfo(line)
+function set_tracking_info(line)
   local _, i = line:find("ahead")
   if i ~= nil then
     git_status.ahead = line:sub(i + 2, i + 2)
@@ -119,7 +123,7 @@ function setTrackingInfo(line)
   end
 end
 
-function getStatus()
+function gather_status_info()
   local status_handle = io.popen("git status --porcelain --branch")
   local status = status_handle:read("*a")
 
@@ -128,16 +132,22 @@ function getStatus()
     local working_tree_status = line:sub(2, 2)
 
     if working_tree_status == "#" and index_status == "#" then
-      setBranchName(line)
-      setTrackingInfo(line)
+      set_branch_name(line)
+      set_tracking_info(line)
     end
 
     if index_status == "A" then
       git_status.staged = git_status.staged + 1
+    elseif index_status == "M" then
+      git_status.staged = git_status.staged + 1
+    elseif index_status == "R" then
+      git_status.staged = git_status.staged + 1
+    elseif index_status == "D" then
+      git_status.staged = git_status.staged + 1
     elseif index_status == "U" then
       git_status.conflicts = git_status.conflicts + 1
     elseif working_tree_status == "M" then
-      git_status.changed = git_status.changed + 1
+      git_status.modified = git_status.modified + 1
     elseif working_tree_status == "D" then
       git_status.deleted = git_status.deleted + 1
     elseif working_tree_status == "?" and index_status == "?" then
@@ -146,20 +156,20 @@ function getStatus()
   end
 
   status_handle:close()
-  setStashCount()
+  set_stash_count()
 end
 
-getStatus()
+gather_status_info()
 if #arg == 0 then
-  longPrint()
+  long_print()
 end
 
 for _, option in ipairs(arg) do
   if option == "--short" or option == "-s" then
-    shortPrint()
+    short_print()
   elseif option == "--prompt" or option == "-p" then
-    promptPrint()
+    prompt_print()
   else
-    longPrint()
+    long_print()
   end
 end

--- a/misc/git_status.lua
+++ b/misc/git_status.lua
@@ -1,0 +1,165 @@
+#!/usr/bin/env lua
+-- Git status docs: https://git-scm.com/docs/git-status
+
+local git_status = {
+  branch = '',
+  behind = 0,
+  ahead = 0,
+  conflicts = 0,
+  staged = 0,
+  changed = 0,
+  deleted = 0,
+  untracked = 0,
+  stashed = 0,
+}
+
+function promptPrint()
+  local prompOutput = {
+    branch = "%{$fg_bold[magenta]%}",
+    behind = "%{↓%G%}",
+    ahead = "%{↑%G%}",
+    conflicts = "%{$fg[red]%}%{✖%G%}",
+    staged = "%{$fg[red]%}%{●%G%}",
+    changed = "%{$fg_bold[green]%}%{+%G%}",
+    deleted = "%{$fg_bold[blue]%}%{-%G%}",
+    untracked = "%{$fg[cyan]%}%{?%G%}",
+    stashed = "%{$fg_bold[blue]%}%{⚑%G%}",
+    reset = "%{$reset_color%}"
+  }
+
+  for key, value in pairs(git_status) do
+    if value and value ~= 0 then
+      prompOutput[key] = prompOutput[key] .. value .. prompOutput.reset
+    else
+      prompOutput[key] = ''
+    end
+  end
+
+  print(
+    prompOutput.branch ..
+    prompOutput.behind ..
+    prompOutput.ahead ..
+    prompOutput.conflicts ..
+    prompOutput.staged ..
+    prompOutput.changed ..
+    prompOutput.deleted ..
+    prompOutput.untracked ..
+    prompOutput.stashed
+  )
+end
+
+function longPrint()
+  for k, v in pairs(git_status) do
+    print(k .. " " .. v)
+  end
+end
+
+function shortPrint()
+  print(
+    git_status.branch .. " " ..
+    git_status.behind .. " " ..
+    git_status.ahead .. " " ..
+    git_status.conflicts .. " " ..
+    git_status.staged .. " " ..
+    git_status.changed .. " " ..
+    git_status.deleted .. " " ..
+    git_status.untracked .. " " ..
+    git_status.stashed
+  )
+end
+
+function setStashCount()
+  stash_handle = io.popen('git stash list | grep "$(git rev-parse --abbrev-ref HEAD)" | wc -l')
+  git_status.stashed = stash_handle:read("n")
+  stash_handle:close()
+end
+
+function getTagOrRef()
+  local tag_handle = io.popen("git describe --tags")
+  local tag = tag_handle:read("*a")
+  tag_handle:close()
+
+  if tag then
+    return tag
+  else
+    local ref_handle = io.popen("git rev-parse --short HEAD")
+    local ref = ref_handle:read("*a")
+    ref_handle:close()
+
+    return ref
+  end
+end
+
+function setBranchName(line)
+  if line:find("Initial commit on") or line:find("No commits yet on") then
+    git_status.branch = line:match("(%S+)%s*$")
+  elseif line:find("no branch") then
+    git_status.branch = getTagOrRef()
+  else
+    local name_start = 4
+    local name_end = line:find("%.%.%.")
+    if name_end then
+      name_end = name_end - 1
+    else
+      name_end = #line
+    end
+    git_status.branch = line:sub(name_start, name_end)
+  end
+end
+
+function setTrackingInfo(line)
+  local _, i = line:find("ahead")
+  if i ~= nil then
+    git_status.ahead = line:sub(i + 2, i + 2)
+  end
+
+  local _, j = line:find("behind")
+  if j ~= nil then
+    git_status.behind = line:sub(j + 2, j + 2)
+  end
+end
+
+function getStatus()
+  local status_handle = io.popen("git status --porcelain --branch")
+  local status = status_handle:read("*a")
+
+  for line in status:gmatch("[^\r\n]+") do
+    local index_status = line:sub(1, 1)
+    local working_tree_status = line:sub(2, 2)
+
+    if working_tree_status == "#" and index_status == "#" then
+      setBranchName(line)
+      setTrackingInfo(line)
+    end
+
+    if index_status == "A" then
+      git_status.staged = git_status.staged + 1
+    elseif index_status == "U" then
+      git_status.conflicts = git_status.conflicts + 1
+    elseif working_tree_status == "M" then
+      git_status.changed = git_status.changed + 1
+    elseif working_tree_status == "D" then
+      git_status.deleted = git_status.deleted + 1
+    elseif working_tree_status == "?" and index_status == "?" then
+      git_status.untracked = git_status.untracked + 1
+    end
+  end
+
+  status_handle:close()
+  setStashCount()
+end
+
+getStatus()
+if #arg == 0 then
+  longPrint()
+end
+
+for _, option in ipairs(arg) do
+  if option == "--short" or option == "-s" then
+    shortPrint()
+  elseif option == "--prompt" or option == "-p" then
+    promptPrint()
+  else
+    longPrint()
+  end
+end

--- a/misc/git_status.lua
+++ b/misc/git_status.lua
@@ -13,8 +13,8 @@ local git_status = {
   stashed = 0,
 }
 
-function promptPrint()
-  local prompOutput = {
+function prompt_print()
+  local promp_output = {
     branch = "%{$fg_bold[magenta]%}",
     behind = "%{↓%G%}",
     ahead = "%{↑%G%}",
@@ -29,32 +29,32 @@ function promptPrint()
 
   for key, value in pairs(git_status) do
     if value and value ~= 0 then
-      prompOutput[key] = prompOutput[key] .. value .. prompOutput.reset
+      promp_output[key] = promp_output[key] .. value .. promp_output.reset
     else
-      prompOutput[key] = ''
+      promp_output[key] = ''
     end
   end
 
   print(
-    prompOutput.branch ..
-    prompOutput.behind ..
-    prompOutput.ahead ..
-    prompOutput.conflicts ..
-    prompOutput.staged ..
-    prompOutput.changed ..
-    prompOutput.deleted ..
-    prompOutput.untracked ..
-    prompOutput.stashed
+    promp_output.branch ..
+    promp_output.behind ..
+    promp_output.ahead ..
+    promp_output.conflicts ..
+    promp_output.staged ..
+    promp_output.changed ..
+    promp_output.deleted ..
+    promp_output.untracked ..
+    promp_output.stashed
   )
 end
 
-function longPrint()
+function long_print()
   for k, v in pairs(git_status) do
     print(k .. " " .. v)
   end
 end
 
-function shortPrint()
+function short_print()
   print(
     git_status.branch .. " " ..
     git_status.behind .. " " ..
@@ -68,33 +68,37 @@ function shortPrint()
   )
 end
 
-function setStashCount()
+function set_stash_count()
   stash_handle = io.popen('git stash list | grep "$(git rev-parse --abbrev-ref HEAD)" | wc -l')
   git_status.stashed = stash_handle:read("n")
   stash_handle:close()
 end
 
-function getTagOrRef()
-  local tag_handle = io.popen("git describe --tags")
+function get_tag_or_ref()
+  local tag_handle = io.popen("git describe --tags 2> /dev/null")
   local tag = tag_handle:read("*a")
-  tag_handle:close()
+  local tag_ok = tag_handle:close()
 
-  if tag then
-    return tag
-  else
-    local ref_handle = io.popen("git rev-parse --short HEAD")
-    local ref = ref_handle:read("*a")
-    ref_handle:close()
-
-    return ref
+  if tag_ok and tag then
+    return trim(tag)
   end
+
+  local ref_handle = io.popen("git rev-parse --short HEAD")
+  local ref = ref_handle:read("*a")
+  ref_handle:close()
+
+  return trim(ref) .. "..."
 end
 
-function setBranchName(line)
+function trim(s)
+  return s:match "^%s*(.*)":match "(.-)%s*$"
+end
+
+function set_branch_name(line)
   if line:find("Initial commit on") or line:find("No commits yet on") then
     git_status.branch = line:match("(%S+)%s*$")
   elseif line:find("no branch") then
-    git_status.branch = getTagOrRef()
+    git_status.branch = get_tag_or_ref()
   else
     local name_start = 4
     local name_end = line:find("%.%.%.")
@@ -107,7 +111,7 @@ function setBranchName(line)
   end
 end
 
-function setTrackingInfo(line)
+function set_tracking_info(line)
   local _, i = line:find("ahead")
   if i ~= nil then
     git_status.ahead = line:sub(i + 2, i + 2)
@@ -119,7 +123,7 @@ function setTrackingInfo(line)
   end
 end
 
-function getStatus()
+function gather_status_info()
   local status_handle = io.popen("git status --porcelain --branch")
   local status = status_handle:read("*a")
 
@@ -128,8 +132,8 @@ function getStatus()
     local working_tree_status = line:sub(2, 2)
 
     if working_tree_status == "#" and index_status == "#" then
-      setBranchName(line)
-      setTrackingInfo(line)
+      set_branch_name(line)
+      set_tracking_info(line)
     end
 
     if index_status == "A" then
@@ -146,20 +150,20 @@ function getStatus()
   end
 
   status_handle:close()
-  setStashCount()
+  set_stash_count()
 end
 
-getStatus()
+gather_status_info()
 if #arg == 0 then
-  longPrint()
+  long_print()
 end
 
 for _, option in ipairs(arg) do
   if option == "--short" or option == "-s" then
-    shortPrint()
+    short_print()
   elseif option == "--prompt" or option == "-p" then
-    promptPrint()
+    prompt_print()
   else
-    longPrint()
+    long_print()
   end
 end

--- a/setup.sh
+++ b/setup.sh
@@ -46,6 +46,7 @@ install_programs() {
     ranger
     ripgrep
     fd-find
+    zsh-syntax-highlighting
   )
 
   info_message "Installing programs"
@@ -60,23 +61,6 @@ install_programs() {
   else
     error_message "No known way of installing programs"
   fi
-}
-
-install_ohmyzsh() {
-  if [ -d "$HOME/.oh-my-zsh" ]; then
-    info_message "Oh-my-zsh is already inslled, trying to update"
-    omz update >/dev/null
-  else
-    info_message "Installing oh-my-zsh"
-    exit | sh -c "$(command curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" >/dev/null
-  fi
-
-  info_message "Installing syntax highlighting plugin"
-  command git clone "https://github.com/zsh-users/zsh-syntax-highlighting.git" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting" 2>/dev/null
-
-  info_message "Installing custom theme"
-  local custom_theme="attempt"
-  command ln -sfv "$install_dir/themes/$custom_theme.zsh-theme" "$HOME/.oh-my-zsh/custom/themes"
 }
 
 switch_git_branch() {
@@ -122,9 +106,7 @@ install() {
   backup_files
   get_dotfiles_from_git
   install_programs
-  install_ohmyzsh
   link_dotfiles
-  source "$install_dir/misc/extended-setup.sh"
 }
 
 install

--- a/themes/attempt.zsh-theme
+++ b/themes/attempt.zsh-theme
@@ -1,8 +1,12 @@
 export PROMPT_SHOW_USER_INFO=0
 export PROMPT_DIRECTORY_DEPTH="2" # empty string for full path
+export PROMPT_GIT_INFO=1
+export LS_COLORS="rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.avif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:*~=00;90:*#=00;90:*.bak=00;90:*.old=00;90:*.orig=00;90:*.part=00;90:*.rej=00;90:*.swp=00;90:*.tmp=00;90:*.dpkg-dist=00;90:*.dpkg-old=00;90:*.ucf-dist=00;90:*.ucf-new=00;90:*.ucf-old=00;90:*.rpmnew=00;90:*.rpmorig=00;90:*.rpmsave=00;90:"
+
+setopt PROMPT_SUBST
 
 local username() {
-   if [[ $PROMPT_SHOW_USER_INFO == 1 ]];then
+   if [[ $PROMPT_SHOW_USER_INFO -eq 1 ]];then
       echo "[%B%{$FG[012]%}%n%f@%{$FG[012]%}$HOST%f%b]-"
    fi
 }
@@ -19,29 +23,23 @@ local return_status() {
    echo " %(?..%{$fg[red]%}✘%f|)"
 }
 
+local git_repo_name() {
+  echo $(basename `git rev-parse --show-toplevel`)
+}
+
 # If the current directory is a git repo, show git information
-local git_info(){
-   if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) ]]; then
-     echo "-[%B$(git_repo_name)%b:%B$(git_super_status)$b]"
+local git_info() {
+   if [[ $PROMPT_GIT_INFO -eq 1 ]] && $(git rev-parse --is-inside-work-tree 2> /dev/null); then
+     echo -e "-[%B$(git_repo_name)%b:%B$(lua $DOTFILES/misc/git_status.lua --prompt)%b]"
    fi
 }
 
-# set the git_prompt_info text
-ZSH_THEME_GIT_PROMPT_PREFIX=""
-ZSH_THEME_GIT_PROMPT_SUFFIX=""
-ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}%{?%G%}"
-ZSH_THEME_GIT_PROMPT_DELETED="%{$fg_bold[blue]%}%{-%G%}"
-ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg_bold[green]%}%{+%G%}"
-ZSH_THEME_GIT_PROMPT_CLEAN=""
-ZSH_THEME_GIT_PROMPT_DIRTY=""
-ZSH_THEME_GIT_PROMPT_SEPARATOR=""
-
-# set vi_mode_prompt_info options
-INSERT_MODE_INDICATOR="%(?.%B%{$fg[green]%}\u276f%{$reset_color%}%b.%B%{$fg[red]%}\u276f%{$reset_color%}%b"
-MODE_INDICATOR="%F{yellow}\u276e%f"
-VI_MODE_RESET_PROMPT_ON_MODE_CHANGE=true
+local prompt_indicator(){
+  echo "%(?.%B%{$fg[green]%}\u276f%{$reset_color%}%b.%B%{$fg[red]%}\u276f%{$reset_color%}%b"
+}
 
 # putting it all together
-PROMPT='$(username)[%B$(directory)%b]$(git_info)
-$(vi_mode_prompt_info)'
-RPROMPT='$(return_status)[$(current_time)]'
+precmd() {
+  PROMPT="$(username)[%B$(directory)%b]$(git_info)"$'\n'"$(prompt_indicator)"
+  RPROMPT="$(return_status)[$(current_time)]"
+}

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -13,10 +13,6 @@ if [ $(command -v "apt") ]; then
   alias acp="apt-cache policy"
 fi
 
-if [ $(command -v "mvn") ]; then
-  alias jcp="mvn archetype:generate -DarchetypeArtifactId=maven-archetype-boilerplate -DarchetypeGroupId=com.boilerplate"
-fi
-
 alias mv="mv -i"
 alias cp="cp -i"
 alias cl="clear"
@@ -25,3 +21,10 @@ alias e="nvim"
 alias ee="subl"
 alias af="alias | grep"
 alias cdot="cd ~/.dotfiles"
+
+alias ls='ls --color=tty'
+alias ll='ls -lh --color=tty'
+
+alias ..="cd .."
+alias ...="cd ../.."
+alias ....="cd ../../.."

--- a/zsh/key-bindings.zsh
+++ b/zsh/key-bindings.zsh
@@ -35,5 +35,14 @@ zle -N __open_in_editor
  
 # bind keys to widgets
 bindkey -M viins '^u' __open_in_editor
+
 #bindkey -M vicmd '^u' __open_in_editor
 bindkey -M viins '^f' vi-cmd-mode 
+
+# open buffer line in editor
+autoload -Uz edit-command-line
+zle -N edit-command-line
+bindkey '^x^e' edit-command-line
+
+# shift-tab for selecting previous completion item 
+bindkey '^[[Z' reverse-menu-complete

--- a/zsh/zshrc.slink
+++ b/zsh/zshrc.slink
@@ -1,20 +1,27 @@
 export EDITOR=nvim
-export ZSH="$HOME/.oh-my-zsh"
+export DOTFILES="$HOME/.dotfiles"
 
-DOTFILES="$HOME/.dotfiles"
-#ZSH_THEME="robbyrussell"
-ZSH_THEME="attempt"
+autoload -U colors && colors
 
 # Load mise
 [ -f "$HOME/.local/bin/mise" ] && eval "$($HOME/.local/bin/mise activate zsh)"
 
-plugins=(git-prompt vi-mode zsh-syntax-highlighting)
-
-source $ZSH/oh-my-zsh.sh
 source $DOTFILES/misc/ssh-agent.sh
+source $DOTFILES/themes/attempt.zsh-theme
+
+if [ -f "/usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]; then
+  source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+fi
 
 # Source .zsh files
 for src in $(find -H "$DOTFILES" -maxdepth 2 -name "*.zsh")
 do
-    source $src 2> /dev/null
+  source $src 2> /dev/null
 done
+
+# Enable case-insensitive completion
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+# Enable completion menu and select
+zstyle ':completion:*' menu select
+# Colorize completions using default `ls` colors. 
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"


### PR DESCRIPTION
-removed the installation of oh-my-zsh from from the setup.sh script
-removed the installation of oh-my-zsh plugins from the setup.sh script
-added the installation of zsh-syntax-highlighting via the package manager
-removed the call to 'extended-setup.sh' at the end of the setup script
-updated the theme to use a custom git status script and removed the vi omz plugin references
-added a custom lua script for fetching git info
-added a custom value for LS_COLORS
-added aliases for ls and cd
-added a zsh keybinding for editing the command line in the $EDITOR
-added zsh case-insensitive completion
-added a zsh completion menu
-removed all references of omz in the zshrc.slink
-removed git aliases which were using a method from the omz git plugin