### PR TITLE
(alacritty, tmux): new default font, font fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## Recommended fonts:
 - [Meslo Nerd Font](https://github.com/romkatv/powerlevel10k/blob/master/font.md)
 - [JetBrains Mono](https://github.com/JetBrains/JetBrainsMono)
+- [Commit Mono](https://github.com/eigilnikolajsen/commit-mono)
 
 ## Install
 ```sh

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,9 +1,9 @@
 [font] 
 size = 11
-normal = {family = "JetBrains Mono", style = "Regular"}
-bold = {family = "JetBrains Mono", style = "Bold"}
-italic = {family = "JetBrains Mono", style = "Italic"}
-bold_italic = {family = "JetBrains Mono", style = "Bold Italic"}
+normal = { family = "CommitMono Nerd Font", style = "Regular" }
+bold = { style = "Bold" }
+italic = { style = "Italic" }
+bold_italic = { style = "Bold Italic" }
 
 [terminal.shell]
 program = "/bin/zsh"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -62,7 +62,7 @@ bind-key r source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."
 
 # Theme
 # Basic color support setting
-set-option -g default-terminal "screen-256color"
+set-option -g default-terminal "tmux-256color"
 
 # Default bar color
 set-option -g status-style bg='#191724'


### PR DESCRIPTION
-Updated the alacritty config to use Commit Mono Nerd Font as the defautl font
-Updated the default terminal in the tmux config to fix the italics font not showing
-Updated the README.md with a link to Commit Mono